### PR TITLE
Reverse check for docker sock mount

### DIFF
--- a/policy/deny.rego
+++ b/policy/deny.rego
@@ -95,6 +95,6 @@ deny[msg] {
 # https://kubesec.io/basics/spec-volumes-hostpath-path-var-run-docker-sock/
 deny[msg] {
 	kubernetes.volumes[volume]
-	not volume.hostpath.path = "/var/run/docker.sock"
+	volume.hostpath.path = "/var/run/docker.sock"
 	msg = sprintf("The %s %s is mounting the Docker socket", [kubernetes.kind, kubernetes.name])
 }


### PR DESCRIPTION
Original check will throw a deny if a `Deployment` resource has a `volumes` section and DOES NOT have a path mounted to `/var/run/docker.sock`. This is the inverse behavior we want so we should drop the `not` here :)